### PR TITLE
Add --no-cancel to "counting translated messages"

### DIFF
--- a/tree/usr/bin/eltrans
+++ b/tree/usr/bin/eltrans
@@ -1021,7 +1021,7 @@ translate_new(){
         #echo -e "$( eval_gettext "Basically, your Desktop and Graphical interface/system." )" >> "$tempfile"
 
         { echo 10 ; sleep 30 ; } \
-            | $guitool --progress --text="$( eval_gettext "Counting translated messages..." )" --pulsate &
+            | $guitool --progress --text="$( eval_gettext "Counting translated messages..." )" --pulsate --no-cancel &
         pid_guitool_counting=$!
 
         for item_v in ${translating_d}/elive/*


### PR DESCRIPTION
This commit adds the --no-cancel parameter to the progress-bar that says
"Counting translated messages...", the cancel button doesn't do anything
so people will get confuzzled if eltrans continues even after clicking
cancel. This is purely a UX commit.

I opened the "allow edits by maintainers" so feel free to go onto my fork
and make updates. :D 